### PR TITLE
Comment out `baseurl`

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 timezone:    Europe/Berlin
 future:      false
 # Set baseurl to the base path of the site eg "/mytalk"
-baseurl:     "/github-slideshow"
+# baseurl:     "/github-slideshow"
 # The allowed values are 'rouge', 'pygments' or null.
 highlighter: rouge
 # markdown - Valid options are [ maruku | rdiscount | kramdown | redcarpet ]


### PR DESCRIPTION
👋 This PR removes the `baseurl` from Jekyll's `_config.yml`. It was causing issues with this course on GitHub Enterprise Server, and isn't needed on the Cloud version of Learning Lab to work.

The issue on GHES: the site would build correctly, but URLs for the `.css` and `.js` files pointed to `ghe.com/github-slideshow/...` instead of `ghe.com/pages/<username>/github-slideshow/...`

I've left it in as a comment, just as a point of information for the learner!